### PR TITLE
feat: Add new role packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ This repository is used to configure hosts inside the Mila infrastructure.
 * mount
 * msmtp
 * multipath
+* [packages](roles/packages/README.md)
 * sssd
 * time

--- a/roles/packages/README.md
+++ b/roles/packages/README.md
@@ -1,0 +1,18 @@
+# Packages
+
+A simple role for installing/removing packages without any configuration steps.
+
+To install a package, add it to `packages_install_list`:
+
+```yaml
+packages_install_list:
+  - ansible
+  - python3
+```
+
+To remove a package, add it to `packages_remove_list`:
+
+```yaml
+packages_remove_list:
+  - puppet
+```

--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# List of packages to install
+packages_install_list: []
+
+# List of packages to remove
+packages_remove_list: []

--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Check legacy packages variables
+  ignore_errors: true
+  when: packages_present is defined or packages_absent is defined
+  ansible.builtin.fail:
+    msg: "WARNING: Variables `packages_present` and `packages_absent` are deprecated"
+
+- name: Install packages
+  ansible.builtin.package:
+    name: "{{ packages_install_list + (packages_present | default([])) }}"
+    state: present
+
+- name: Uninstall packages
+  ansible.builtin.package:
+    name: "{{ packages_remove_list + (packages_absent | default([])) }}"
+    state: absent


### PR DESCRIPTION
This role helps to install and remove packages from a Linux host.

While this is a new role in this collection, it is inspired from two roles used in two different projects. This explains the existence of deprecated variables `packages_present` and `packages_absent` which will allow to use this new roles in the playbooks first, then to update the inventories.