### PR TITLE
fix: Check cvmfs_config_repo.repository is defined

### DIFF
--- a/roles/cvmfs_opts/tasks/main.yml
+++ b/roles/cvmfs_opts/tasks/main.yml
@@ -7,7 +7,10 @@
     owner: root
     group: root
     mode: 0644
-  when: cvmfs_config_repo is defined and cvmfs_config_repo_supported
+  when:
+    - cvmfs_config_repo is defined
+    - cvmfs_config_repo.repository is defined
+    - cvmfs_config_repo_supported
   notify:
     - Reload autofs
 


### PR DESCRIPTION
Avoid task failure when cvmfs_config_repo is defined but empty.