### PR TITLE
feat: Add new role environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository is used to configure hosts inside the Mila infrastructure.
 
 * cgroups
 * cvmfs_opts
+* [environment](roles/environment/README.md)
 * fail2ban
 * local_users
 * modules

--- a/roles/environment/README.md
+++ b/roles/environment/README.md
@@ -1,0 +1,5 @@
+# Environment
+
+Configure `/etc/environment` and `/etc/profile.d/`.
+
+Check [defaults/main.yml](defaults/main.yml) for configuration variables.

--- a/roles/environment/defaults/main.yml
+++ b/roles/environment/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# Define environment variables in /etc/environment
+# environment_file: |
+#   ARCH={{ ansible_facts['architecture'] }}
+
+# Define files to install in /etc/profile.d/
+# environment_profile_files:
+#   - name: 01-cluster.sh
+#     content: |
+#       export SCRATCH="/scratch/${USER:0:1}/${USER}"
+#   - name: 02-foo.sh
+#     state: absent
+environment_profile_files: []
+
+# Source /etc/profile.d/*.sh in bashrc
+environment_source_profiled: true
+
+# Enable/disable integration with CC/DRAC environment
+environment_cc_env: false

--- a/roles/environment/tasks/cc_env.yml
+++ b/roles/environment/tasks/cc_env.yml
@@ -1,0 +1,21 @@
+---
+- name: Use lesspipe from DRAC StdEnv
+  when: ansible_facts['os_family'] == "Debian"
+  ansible.builtin.lineinfile:
+    path: /etc/skel/.bashrc
+    regexp: '^(\[ -x /usr/bin/lesspipe \].*)'
+    line: '# Use lesspipe from DRAC StdEnv # \g<1>'
+    backrefs: true
+
+- name: Ensure CC_CLUSTER is defined in /etc/environment
+  block:
+    - name: Read /etc/environment
+      check_mode: false
+      ansible.builtin.slurp:
+        src: /etc/environment
+      register: __etc_environment
+
+    - name: Check for CC_CLUSTER
+      ansible.builtin.assert:
+        that: __etc_environment['content'] | b64decode | regex_search('^CC_CLUSTER=', multiline=True)
+        fail_msg: "CC_CLUSTER must be set in /etc/environment when `environment_cc_env=true`"

--- a/roles/environment/tasks/main.yml
+++ b/roles/environment/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure /etc/environment
+  when: environment_file is defined
+  ansible.builtin.copy:
+    content: "{{ environment_file }}"
+    dest: /etc/environment
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Source /etc/profile.d/ in bashrc
+  ansible.builtin.blockinfile:
+    insertafter: "^# System-wide .bashrc.*"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - SOURCE /etc/profile.d/"
+    path: /etc/bash.bashrc
+    owner: root
+    group: root
+    mode: '0644'
+    state: "{{ environment_source_profiled | bool | ternary('present', 'absent') }}"
+    block: "{{ __environment_profiled_bashrc }}"
+
+- name: Configure /etc/profile.d/
+  loop: "{{ environment_profile_files }}"
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: "/etc/profile.d/{{ item.name }}"
+    owner: root
+    group: root
+    mode: '0644'
+    state: "{{ item.state | default('present') }}"
+
+- name: Import tasks for CC/DRAC environments
+  when: environment_cc_env
+  ansible.builtin.import_tasks: cc_env.yml

--- a/roles/environment/vars/main.yml
+++ b/roles/environment/vars/main.yml
@@ -1,0 +1,15 @@
+---
+# Source /etc/profile.d/*.sh in bashrc
+__environment_profiled_bashrc: |
+  SHELL=/bin/bash
+  # Only display echos from profile.d scripts if we are no login shell
+  # and interactive - otherwise just process them to set envvars
+  for i in /etc/profile.d/*.sh; do
+      if [ -r "$i" ]; then
+          if [ "$PS1" ]; then
+              . "$i"
+          else
+              . "$i" >/dev/null
+          fi
+      fi
+  done


### PR DESCRIPTION
This role configures environment files on hosts. It is inspired by private role `mila.environment.common` and should provide an easy replacement.

It also supports the setting of environment configuration required when a host is part of a cluster that must be compatible with the CC/DRAC environment.