### PR TITLE
Remove dependency to Mila's CVMFS in the "modules" role

### DIFF
--- a/roles/environment/README.md
+++ b/roles/environment/README.md
@@ -8,6 +8,7 @@ initialization scripts.
 * Configure `/etc/environment` with system-wide environment variables
 * Manage shell initialization scripts in `/etc/profile.d/`
 * Configure bash to source `/etc/profile.d/` in `/etc/bash.bashrc`
+* Manage fish shell configuration in `/etc/fish/conf.d/` (when fish is installed)
 * Support CC/DRAC environment configuration
 * Configure HTTP proxy module for Lmod
 
@@ -20,6 +21,7 @@ Check [defaults/main.yml](defaults/main.yml) for configuration variables.
 * `environment_file`: Content for `/etc/environment`
 * `environment_source_profiled`: Whether to source `/etc/profile.d/` in bash (default: true)
 * `environment_profile_files`: List of files to manage in `/etc/profile.d/`
+* `environment_fish_files`: List of files to manage in `/etc/fish/conf.d/`
 * `environment_cc_env`: Whether to configure CC/DRAC environment (default: false)
 * `environment_proxy_http`: HTTP proxy URL for Lmod configuration
 * `environment_proxy_https`: HTTPS proxy URL for Lmod configuration
@@ -40,6 +42,11 @@ Check [defaults/main.yml](defaults/main.yml) for configuration variables.
         content: |
           # Custom environment variables
           export CUSTOM_VAR=value
+    environment_fish_files:
+      - name: 99-custom.fish
+        content: |
+          # Custom fish environment variables
+          set -x CUSTOM_VAR value
     environment_proxy_http: http://squid.example.tld:3128
     environment_proxy_https: http://squid.example.tld:3128
     environment_proxy_rsync: squid.example.tld:3128

--- a/roles/environment/README.md
+++ b/roles/environment/README.md
@@ -1,5 +1,53 @@
 # Environment
 
-Configure `/etc/environment` and `/etc/profile.d/`.
+This role manages system-wide environment configuration files and shell
+initialization scripts.
+
+## Features
+
+* Configure `/etc/environment` with system-wide environment variables
+* Manage shell initialization scripts in `/etc/profile.d/`
+* Configure bash to source `/etc/profile.d/` in `/etc/bash.bashrc`
+* Support CC/DRAC environment configuration
+* Configure HTTP proxy module for Lmod
+
+## Role Variables
 
 Check [defaults/main.yml](defaults/main.yml) for configuration variables.
+
+### Main Variables
+
+* `environment_file`: Content for `/etc/environment`
+* `environment_source_profiled`: Whether to source `/etc/profile.d/` in bash (default: true)
+* `environment_profile_files`: List of files to manage in `/etc/profile.d/`
+* `environment_cc_env`: Whether to configure CC/DRAC environment (default: false)
+* `environment_proxy_http`: HTTP proxy URL for Lmod configuration
+* `environment_proxy_https`: HTTPS proxy URL for Lmod configuration
+* `environment_proxy_rsync`: Rsync proxy URL for Lmod configuration
+* `environment_no_proxy`: Comma-separated list of hosts that should not be proxied
+
+## Example Playbook
+
+```yaml
+- hosts: servers
+  become: true
+  vars:
+    environment_file: |
+      PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      LANG=en_US.UTF-8
+    environment_profile_files:
+      - name: 99-custom.sh
+        content: |
+          # Custom environment variables
+          export CUSTOM_VAR=value
+    environment_proxy_http: http://squid.example.tld:3128
+    environment_proxy_https: http://squid.example.tld:3128
+    environment_proxy_rsync: squid.example.tld:3128
+    environment_no_proxy: example.tld
+  roles:
+    - mila.linux_system.environment
+```
+
+## Dependencies
+
+None

--- a/roles/environment/defaults/main.yml
+++ b/roles/environment/defaults/main.yml
@@ -15,6 +15,9 @@ environment_profile_files: []
 # Source /etc/profile.d/*.sh in bashrc
 environment_source_profiled: true
 
+# List of files to manage in /etc/fish/conf.d/
+environment_fish_files: []
+
 # Enable/disable integration with CC/DRAC environment
 environment_cc_env: false
 

--- a/roles/environment/tasks/main.yml
+++ b/roles/environment/tasks/main.yml
@@ -36,6 +36,32 @@
     path: "/etc/profile.d/{{ item.name }}"
     state: absent
 
+- name: Check if fish conf.d directory exists
+  ansible.builtin.stat:
+    path: /etc/fish/conf.d
+  register: __fish_confd
+
+- name: Configure /etc/fish/conf.d/
+  loop: "{{ environment_fish_files }}"
+  when:
+    - __fish_confd.stat.exists
+    - item.state is not defined or item.state == "present"
+  ansible.builtin.copy:
+    content: "{{ item.content }}"
+    dest: "/etc/fish/conf.d/{{ item.name }}"
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Cleanup /etc/fish/conf.d/
+  loop: "{{ environment_fish_files }}"
+  when:
+    - __fish_confd.stat.exists
+    - item.state is defined and item.state == "absent"
+  ansible.builtin.file:
+    path: "/etc/fish/conf.d/{{ item.name }}"
+    state: absent
+
 - name: Import tasks for CC/DRAC environments
   when: environment_cc_env
   ansible.builtin.import_tasks: cc_env.yml

--- a/roles/modules/README.md
+++ b/roles/modules/README.md
@@ -65,9 +65,5 @@ None
 
 ## Notes
 
-* The role assumes the presence of CVMFS for accessing Mila-specific configurations:
-  * `/cvmfs/ai.mila.quebec/` for Lmod initialization scripts
-* Shell configurations are installed in the appropriate system directories:
-  * `/etc/fish/conf.d/` for fish (Debian only)
-  * `/etc/zsh/` for zsh profile
-* Module system is configured to work with the Mila software stack
+* The role installs a global zsh profile by copying a `zprofile` file to
+  `/etc/zsh/` that sources `/etc/profile`.

--- a/roles/modules/README.md
+++ b/roles/modules/README.md
@@ -14,9 +14,7 @@ environment across different Linux distributions.
   * Bash profile integration
   * Csh/Tcsh integration
   * Fish shell integration (Debian only)
-* Sets up Mila-specific configurations:
-  * Links Mila default profiles
-  * Configures Lmod initialization scripts
+  * Zsh profile configuration
 
 ## Role Variables
 
@@ -43,7 +41,6 @@ None
 * Installs additional shells:
   * fish
   * zsh
-* Configures all shell environments (bash, csh, fish)
 
 ### RedHat/CentOS
 * Installs Lua and required packages:
@@ -52,7 +49,6 @@ None
   * lua-filesystem
   * lua-posix
   * tcl
-* Configures bash and csh environments
 
 ## Example Playbook
 
@@ -70,10 +66,8 @@ None
 ## Notes
 
 * The role assumes the presence of CVMFS for accessing Mila-specific configurations:
-  * `/cvmfs/config.mila.quebec/` for Mila profiles
   * `/cvmfs/ai.mila.quebec/` for Lmod initialization scripts
 * Shell configurations are installed in the appropriate system directories:
-  * `/etc/profile.d/` for bash and csh
   * `/etc/fish/conf.d/` for fish (Debian only)
   * `/etc/zsh/` for zsh profile
 * Module system is configured to work with the Mila software stack

--- a/roles/modules/tasks/main.yml
+++ b/roles/modules/tasks/main.yml
@@ -38,34 +38,6 @@
     group: root
     mode: '0755'
 
-- name: Mila default profile bash
-  ansible.builtin.file:
-    src: /cvmfs/config.mila.quebec/etc/profile.d/.z00_Mila.sh
-    dest: /etc/profile.d/z99_Mila.sh
-    state: link
-    force: true
-
-- name: Mila default profile bourne
-  ansible.builtin.file:
-    src: /cvmfs/config.mila.quebec/etc/profile.d/.z00_Mila.csh
-    dest: /etc/profile.d/z99_Mila.csh
-    state: link
-    force: true
-
-- name: Lmod bash
-  ansible.builtin.file:
-    src: /cvmfs/ai.mila.quebec/apps/{{ ansible_facts['architecture'] }}/{{ ansible_facts['os_family'] | lower }}/lmod/lmod/init/profile
-    dest: /etc/profile.d/z00_lmod.sh
-    state: link
-    force: true
-
-- name: Lmod bourne
-  ansible.builtin.file:
-    src: /cvmfs/ai.mila.quebec/apps/{{ ansible_facts['architecture'] }}/{{ ansible_facts['os_family'] | lower }}/lmod/lmod/init/cshrc
-    dest: /etc/profile.d/z00_lmod.csh
-    state: link
-    force: true
-
 - name: Lmod fish
   ansible.builtin.file:
     src: /cvmfs/ai.mila.quebec/apps/{{ ansible_facts['architecture'] }}/{{ ansible_facts['os_family'] | lower }}/lmod/lmod/init/profile.fish

--- a/roles/modules/tasks/main.yml
+++ b/roles/modules/tasks/main.yml
@@ -37,11 +37,3 @@
     owner: root
     group: root
     mode: '0755'
-
-- name: Lmod fish
-  ansible.builtin.file:
-    src: /cvmfs/ai.mila.quebec/apps/{{ ansible_facts['architecture'] }}/{{ ansible_facts['os_family'] | lower }}/lmod/lmod/init/profile.fish
-    dest: /etc/fish/conf.d/z00_lmod.fish
-    state: link
-    force: true
-  when: ansible_facts['os_family'] == 'Debian'


### PR DESCRIPTION
Prefer the `environment` role to configure `/etc/profile.d/` on a
system. Remove the creation of the symlinks to Mila's CVMFS. This helps
to make the collection more agnostic.

Remove the built-in configuration of fish from the `modules` role and
add a new variable `environment_fish_files` to configure fish shell with
the `environment` role.

This removes the dependency on Mila CVMFS in the `modules` role.

Also update the README of the `environment` role.