### PR TITLE
fix: Force 'dnf' backend for older RHEL releases

### DIFF
--- a/roles/modules/tasks/main.yml
+++ b/roles/modules/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - name: Install lua RedHat
   ansible.builtin.dnf:
+    use_backend: "{{ (ansible_facts['distribution_major_version'] | int <= 7) | ternary('dnf', 'auto') }}"
     name:
       - lua
       - lua-json

--- a/roles/multipath/tasks/install-RedHat.yml
+++ b/roles/multipath/tasks/install-RedHat.yml
@@ -2,5 +2,6 @@
 - name: Install multipath packages
   ansible.builtin.dnf:
     update_cache: true
+    use_backend: "{{ (ansible_facts['distribution_major_version'] | int <= 7) | ternary('dnf', 'auto') }}"
     name:
       - device-mapper-multipath


### PR DESCRIPTION
Older RHEL OS use `yum` as package manager instead of `dnf`. Make sure to manually specify use_backend to tell the module whether to use the dnf backend.