### PR TITLE
ci: fix ansible-lint var-naming[no-role-prefix]

### DIFF
--- a/roles/cgroups/tasks/main.yml
+++ b/roles/cgroups/tasks/main.yml
@@ -2,8 +2,8 @@
 - name: Check if cgroup memory in kernel
   ansible.builtin.command: grep -c '^GRUB_CMDLINE_LINUX_DEFAULT=.*cgroup_enable=memory' /etc/default/grub
   changed_when: false
-  register: cgroup_memory
-  failed_when: "cgroup_memory.rc > 1"
+  register: __cgroups_memory
+  failed_when: "__cgroups_memory.rc > 1"
 
 - name: Enable cgroup memory
   ansible.builtin.lineinfile:
@@ -11,17 +11,17 @@
     regexp: 'GRUB_CMDLINE_LINUX_DEFAULT="(.*)"'
     line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 cgroup_enable=memory"'
     backrefs: true
-  when: cgroup_memory.stdout == "0"
+  when: __cgroups_memory.stdout == "0"
 
 - name: Update-grub
   ansible.builtin.command: update-grub2
-  when: cgroup_memory.stdout == "0"
+  when: __cgroups_memory.stdout == "0"
 
 - name: Check if cgroup v2 in kernel
   ansible.builtin.command: grep -c '^GRUB_CMDLINE_LINUX_DEFAULT=.*systemd.unified_cgroup_hierarchy' /etc/default/grub
   changed_when: false
-  register: cgroup_v2
-  failed_when: "cgroup_v2.rc > 1"
+  register: __cgroups_v2
+  failed_when: "__cgroups_v2.rc > 1"
 
 - name: Enable cgroup memory
   ansible.builtin.lineinfile:
@@ -29,11 +29,11 @@
     regexp: 'GRUB_CMDLINE_LINUX_DEFAULT="(.*)"'
     line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 systemd.unified_cgroup_hierarchy"'
     backrefs: true
-  when: cgroup_v2.stdout == "0"
+  when: __cgroups_v2.stdout == "0"
 
 - name: Update-grub
   ansible.builtin.command: update-grub2
-  when: cgroup_v2.stdout == "0"
+  when: __cgroups_v2.stdout == "0"
 
 # Use user-.slice.d drop-in (requires systemd version >= 239)
 - name: Create base directory /etc/systemd/system/user-.slice.d

--- a/roles/environment/tasks/cc_env.yml
+++ b/roles/environment/tasks/cc_env.yml
@@ -13,11 +13,11 @@
       check_mode: false
       ansible.builtin.slurp:
         src: /etc/environment
-      register: __etc_environment
+      register: __environment_etc
 
     - name: Check for CC_CLUSTER
       ansible.builtin.assert:
-        that: __etc_environment['content'] | b64decode | regex_search('^CC_CLUSTER=', multiline=True)
+        that: __environment_etc['content'] | b64decode | regex_search('^CC_CLUSTER=', multiline=True)
         fail_msg: "CC_CLUSTER must be set in /etc/environment when `environment_cc_env=true`"
 
 # See https://docs.alliancecan.ca/wiki/Accessing_CVMFS#CUDA_location
@@ -27,13 +27,13 @@
     - name: List files installed from NVIDIA packages
       ansible.builtin.command: "dpkg -L {{ item }}"
       loop: "{{ environment_cc_env_nvidia_packages }}"
-      register: __libnvidia
+      register: __environment_libnvidia
       changed_when: false
 
     - name: Search files in /usr/lib/x86_64-linux-gnu/.*.so.*
       ansible.builtin.set_fact:
         __libnvidia_files: "{{ __libnvidia_files | default([]) | union(item.stdout_lines | select('search', '^/usr/lib/x86_64-linux-gnu/.*\\.so.*') | list) }}"
-      loop: "{{ __libnvidia.results }}"
+      loop: "{{ __environment_libnvidia.results }}"
       loop_control:
         label: "{{ item.item }}"
 

--- a/roles/environment/tasks/main.yml
+++ b/roles/environment/tasks/main.yml
@@ -39,12 +39,12 @@
 - name: Check if fish conf.d directory exists
   ansible.builtin.stat:
     path: /etc/fish/conf.d
-  register: __fish_confd
+  register: __environment_fish_confd
 
 - name: Configure /etc/fish/conf.d/
   loop: "{{ environment_fish_files }}"
   when:
-    - __fish_confd.stat.exists
+    - __environment_fish_confd.stat.exists
     - item.state is not defined or item.state == "present"
   ansible.builtin.copy:
     content: "{{ item.content }}"
@@ -56,7 +56,7 @@
 - name: Cleanup /etc/fish/conf.d/
   loop: "{{ environment_fish_files }}"
   when:
-    - __fish_confd.stat.exists
+    - __environment_fish_confd.stat.exists
     - item.state is defined and item.state == "absent"
   ansible.builtin.file:
     path: "/etc/fish/conf.d/{{ item.name }}"

--- a/roles/local_users/tasks/admins.yml
+++ b/roles/local_users/tasks/admins.yml
@@ -60,12 +60,12 @@
 - name: Slurp /etc/passwd file
   ansible.builtin.slurp:
     src: /etc/passwd
-  register: _passwd_file
+  register: __local_users_passwd_file
 
 - name: Get list of configured admins from /etc/passwd
   ansible.builtin.set_fact:
     __local_users_configured_admins: '{{ __local_users_configured_admins + [item.split("-") | first] }}'
-  loop: "{{ (_passwd_file['content'] | b64decode).splitlines() |
+  loop: "{{ (__local_users_passwd_file['content'] | b64decode).splitlines() |
      select('match', '^[a-z0-9-.]+:x:[0-9]+:' + local_users_admins_gid | string + ':') |
      list }}"
   no_log: true

--- a/roles/local_users/tasks/operators.yml
+++ b/roles/local_users/tasks/operators.yml
@@ -29,12 +29,12 @@
 - name: Slurp /etc/passwd file
   ansible.builtin.slurp:
     src: /etc/passwd
-  register: _passwd_file
+  register: __local_users_passwd_file
 
 - name: Get list of configured operators from /etc/passwd
   ansible.builtin.set_fact:
     __local_users_configured_operators: '{{ __local_users_configured_operators + [item.split("-") | first] }}'
-  loop: "{{ (_passwd_file['content'] | b64decode).splitlines() |
+  loop: "{{ (__local_users_passwd_file['content'] | b64decode).splitlines() |
      select('match', '^[a-z0-9-.]+:x:[0-9]+:' + local_users_operators_gid | string + ':') |
      list }}"
   no_log: true

--- a/roles/local_users/tasks/service_accounts.yml
+++ b/roles/local_users/tasks/service_accounts.yml
@@ -29,12 +29,12 @@
 - name: Slurp /etc/passwd file
   ansible.builtin.slurp:
     src: /etc/passwd
-  register: _passwd_file
+  register: __local_users_passwd_file
 
 - name: Get list of configured service accounts from /etc/passwd
   ansible.builtin.set_fact:
     __local_users_configured_service_accounts: '{{ __local_users_configured_service_accounts + [item.split("-") | first] }}'
-  loop: "{{ (_passwd_file['content'] | b64decode).splitlines() |
+  loop: "{{ (__local_users_passwd_file['content'] | b64decode).splitlines() |
      select('match', '^[a-z0-9-.]+:x:[0-9]+:' + local_users_service_accounts_gid | string + ':') |
      list }}"
   no_log: true

--- a/roles/motd/tasks/main.yml
+++ b/roles/motd/tasks/main.yml
@@ -7,7 +7,7 @@
         paths: /etc/update-motd.d
         file_type: any
         excludes: "{{ motd_scripts | map(attribute='name') }}"
-      register: __update_motd_d
+      register: __motd_update_motd_d
 
     - name: Disable unmanaged scripts in /etc/update-motd.d
       ansible.builtin.file:
@@ -15,7 +15,7 @@
         owner: root
         group: root
         mode: "0640"
-      loop: "{{ __update_motd_d.files }}"
+      loop: "{{ __motd_update_motd_d.files }}"
       loop_control:
         label: "Disable motd script {{ item.path }}"
 


### PR DESCRIPTION
Variables names from within roles should use role_name_ as a prefix. Underlines are accepted before the prefix.