### PR TITLE
fix: Remove --timeout=0 from cvmfs.autofs

### DIFF
--- a/roles/cvmfs_opts/tasks/main.yml
+++ b/roles/cvmfs_opts/tasks/main.yml
@@ -27,16 +27,3 @@
   when: item.client_configd is defined
   notify:
     - Reload autofs
-
-- name: Ensure /cvmfs /etc/auto.cvmfs --timeout=0 in /etc/auto.master
-  ansible.builtin.lineinfile:
-    path: /etc/auto.master.d/cvmfs.autofs
-    regexp: '^/cvmfs\s+/etc/auto.cvmfs.*'
-    line: '/cvmfs /etc/auto.cvmfs --timeout=0'
-    owner: root
-    group: root
-    mode: '0644'
-    state: present
-    create: true
-  notify:
-    - Reload autofs


### PR DESCRIPTION
This parameter was used as a workaround to fix an issue with Slurm job_container. The job_container configuration parameter `Shared=true` enable using autofs with job_container, which makes this workaround useless.