### PR TITLE
Remove default apt sources from /etc/apt

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: mila
 name: linux_system
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.7.5  # noqa: galaxy[version-incorrect]
+version: 0.7.6  # noqa: galaxy[version-incorrect]
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/repositories/tasks/main.yml
+++ b/roles/repositories/tasks/main.yml
@@ -7,14 +7,17 @@
         file: "repositories-apt.yml"
       loop: "{{ repositories_apt }}"
 
-    - name: Remove /etc/apt/sources.list
+    - name: Remove default APT sources
       when:
         - ansible_facts['os_family'] == "Debian"
         - repositories_remove_apt_sources | bool
       notify: Update repository cache
       ansible.builtin.file:
-        path: /etc/apt/sources.list
+        path: '{{ item.path }}'
         state: absent
+      loop:
+        - { path: /etc/apt/sources.list}
+        - { path: /etc/apt/sources.list.d/debian.sources }
 
 - name: Configure APT priority
   when: item.apt_pin_priority is defined


### PR DESCRIPTION
The main APT sources configuration file is /etc/apt/sources.list.d/debian.sources